### PR TITLE
feat: Refresh token & Access token 적용하여 로그인 동작 변경

### DIFF
--- a/src/components/recruit/recruitDetail/modal/accountDelete/AccountDelete.tsx
+++ b/src/components/recruit/recruitDetail/modal/accountDelete/AccountDelete.tsx
@@ -7,6 +7,7 @@ import { withdrawAccount } from '../../../../../service';
 import secureLocalStorage from 'react-secure-storage';
 
 const ACCESS_TOKEN_KEY = import.meta.env.VITE_ACCESS_TOKEN_KEY;
+const REFRESH_TOKEN_KEY = import.meta.env.VITE_ACCESS_TOKEN_KEY;
 const PLATFORM_ID = import.meta.env.VITE_PLATFORM_ID;
 
 const AccountDelete = () => {
@@ -22,6 +23,7 @@ const AccountDelete = () => {
 			setUserState(null);
 			queryClient.clear();
 			secureLocalStorage.removeItem(ACCESS_TOKEN_KEY);
+			secureLocalStorage.removeItem(REFRESH_TOKEN_KEY);
 			secureLocalStorage.removeItem(PLATFORM_ID);
 		},
 	});

--- a/src/components/recruit/recruitDetail/modal/accountDelete/AccountDelete.tsx
+++ b/src/components/recruit/recruitDetail/modal/accountDelete/AccountDelete.tsx
@@ -7,7 +7,7 @@ import { withdrawAccount } from '../../../../../service';
 import secureLocalStorage from 'react-secure-storage';
 
 const ACCESS_TOKEN_KEY = import.meta.env.VITE_ACCESS_TOKEN_KEY;
-const REFRESH_TOKEN_KEY = import.meta.env.VITE_ACCESS_TOKEN_KEY;
+const REFRESH_TOKEN_KEY = import.meta.env.VITE_REFRESH_TOKEN_KEY;
 const PLATFORM_ID = import.meta.env.VITE_PLATFORM_ID;
 
 const AccountDelete = () => {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@ interface ImportMeta {
 	env: {
 		VITE_BASE_URL: string;
 		VITE_ACCESS_TOKEN_KEY: string;
+		VITE_REFRESH_TOKEN_KEY: string;
 		VITE_NAVER_CLIENT_ID: string;
 		VITE_NAVER_STATE: string;
 		VITE_NAVER_CALLBACK_URL: string;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -13,6 +13,7 @@ import { User } from '../types';
 import secureLocalStorage from 'react-secure-storage';
 
 const ACCESS_TOKEN_KEY = import.meta.env.VITE_ACCESS_TOKEN_KEY;
+const REFRESH_TOKEN_KEY = import.meta.env.VITE_REFRESH_TOKEN_KEY;
 
 const PLATFORM_ID = import.meta.env.VITE_PLATFORM_ID;
 
@@ -36,8 +37,9 @@ export const useCheckExist = ({ onSuccess, setUserState, setLoginState }: AuthPr
 	return useMutation({
 		mutationFn: checkExist,
 		onSuccess: data => {
-			if (data?.accessToken) {
+			if (data?.accessToken && data?.refreshToken) {
 				secureLocalStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
+				secureLocalStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken);
 				setUserState?.({
 					userId: data.userId,
 					nickname: data.nickname,
@@ -61,9 +63,10 @@ export const useNaverSignUp = ({ onSuccess, setUserState, setLoginState }: AuthP
 	return useMutation({
 		mutationFn: signUp,
 		onSuccess: data => {
-			if (data?.accessToken) {
+			if (data?.accessToken && data?.refreshToken) {
 				secureLocalStorage.removeItem(PLATFORM_ID);
 				secureLocalStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
+				secureLocalStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken);
 				setUserState?.({
 					userId: data.userId,
 					nickname: data.nickname,
@@ -131,6 +134,7 @@ export const useSignOut = ({ onSuccess, setUserState, setLoginState }: AuthProps
 		mutationFn: signOut,
 		onSuccess: () => {
 			secureLocalStorage.removeItem(ACCESS_TOKEN_KEY);
+			secureLocalStorage.removeItem(REFRESH_TOKEN_KEY);
 			setUserState?.(null);
 			setLoginState?.(false);
 			onSuccess?.();

--- a/src/service/auth/auth.ts
+++ b/src/service/auth/auth.ts
@@ -1,5 +1,6 @@
 import type { Department, SignUpPayload, University, UserReponse } from '../../types';
 import { EndPoint, axiosAuthInstance, axiosInstance } from '..';
+import axios from 'axios';
 
 const platformType = 'NAVER';
 
@@ -114,5 +115,16 @@ export const withdrawAccount = async () => {
 		return response;
 	} catch (error) {
 		console.error(error);
+	}
+};
+
+export const issueToken = async () => {
+	try {
+		const response = await axios.post<UserReponse>(EndPoint.ISSUE);
+
+		return response;
+	} catch (error) {
+		console.error(error);
+		return null;
 	}
 };

--- a/src/service/endPoint.ts
+++ b/src/service/endPoint.ts
@@ -13,6 +13,7 @@ export const EndPoint = {
 	},
 	SIGN_OUT: '/auth/logout',
 	WITHDRAW: '/user',
+	ISSUE: '/auth/reissue',
 
 	/* profile */
 	PROFILE: {

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -9,6 +9,7 @@ import {
 	readDepartmentList,
 	signOut,
 	withdrawAccount,
+	issueToken,
 } from './auth/auth';
 import {
 	getPostingData,
@@ -80,4 +81,5 @@ export {
 	deletePostingRecruit,
 	readProfileImage,
 	withdrawAccount,
+	issueToken,
 };


### PR DESCRIPTION
# 구현 내용/방법
- 리프레쉬/액세스 토큰 발급 API 함수 추가 및 fetch 적용
- 커스텀 Axios Instance 에 리프레쉬 토큰 적용 동작 추가

# 리뷰 필요
- 액세스 토큰이 만료되어 API 요청에 문제가 생기는 경우, 리프레쉬 토큰으로 다시 액세스/리프레쉬 토큰을 재발급 받고 error response 이용해서 요청날렸던 config로 다시 API 재요청 날리는 로직을 추가하였습니다.
- release-1.0 브랜치에 push 하면 preview 가 빌드되고, main 에 push 하면 production 이 빌드되도록 deployment.yml 파일 수정하였습니다.

제가 놓친 부분이 있다면 말씀 부탁드립니다!

close #111