### PR TITLE
fix: 프로필 이미지 편집 이후, 편집 버튼 누르면 프로필 상세페이지로 리다이렉트 되는 이슈 해결

### DIFF
--- a/src/pages/profile/edit/ProfileEditPage.tsx
+++ b/src/pages/profile/edit/ProfileEditPage.tsx
@@ -20,7 +20,7 @@ import {
 	ModalPortal,
 	Modal,
 } from '../../../components';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { uploadImageState, userState } from '../../../atom';
 import { Skill, Award, Link } from '../../../types';
 import {
@@ -78,6 +78,7 @@ const ProfileEditPage = () => {
 
 	const updateProfileInSuccess = (userId: string) => {
 		navigate(`/profile/${userId}`);
+		setUploadImage(null); // 전역 업로드 이미지 초기화
 	};
 
 	const { mutate: updateProfile } = useUpdateProfile({
@@ -86,7 +87,7 @@ const ProfileEditPage = () => {
 	});
 
 	// 이미지 업로드
-	const uploadImage = useRecoilValue(uploadImageState);
+	const [uploadImage, setUploadImage] = useRecoilState(uploadImageState);
 	const {
 		data: imageResponse,
 		refetch: readImagePresignedUrl,


### PR DESCRIPTION
# 구현 내용/방법

- 프로필 편집 페이지와 프로필 이미지 컴포넌트 내 공유되는 전역 프로필 이미지 상태를 편집 이후에 null로 초기화

# 리뷰 필요
- 전역 프로필 이미지를 편집 이후에 null로 초기화하여, 프로필 편집 이후 프로필 편집 페이지로 다시 들어갔을 때 해당 이미지(uploadImage)로 인해 useEffect 내 로직(S3 내 프로필 이미지 업로드 및 프로필 편집)이 재트리거되어 리다이렉트 되는 문제를 해결하였습니다.

제가 놓친 부분이 있다면 말씀 부탁드립니다!

close #259

